### PR TITLE
Make variable substitution case-sensitive

### DIFF
--- a/src/VariableProcessor.ts
+++ b/src/VariableProcessor.ts
@@ -483,7 +483,7 @@ export class VariableProcessor {
         let result = template;
 
         for (const [key, value] of Object.entries(variables)) {
-            const regex = new RegExp(this.escapeRegExp(key), "gi");
+            const regex = new RegExp(this.escapeRegExp(key), "g");
             result = result.replace(regex, value);
         }
 


### PR DESCRIPTION
The previous case-insensitive substitution with the `i` flag meant that `{mm}` and `{MM}` would both the replaced with the same value (month at the moment) instead of minutes of the hour and month of the day, respectively.